### PR TITLE
fix: sped up mobile navbar load times

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,6 @@ import clsx from "clsx";
 
 const Navbar: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const [container, setContainer] = useState(null);
 
   const [blur, setBlur] = useState(false);
 
@@ -89,6 +88,7 @@ const Navbar: React.FC = () => {
           open={open}
           onOpenChange={setOpen}
           noBodyStyles={true}
+          handleOnly={true}
         >
           <Drawer.Trigger asChild>
             <button className="">


### PR DESCRIPTION
The issue is related to the drawer dragging feature. The drawer can be dragged from anywhere the drawer is pressed, but that makes it hard to distinguish between a drawer drag and a link select. Preventing the drawer from being dragged should fix the issue.